### PR TITLE
Exclude clojure.core/update to avoid warnings

### DIFF
--- a/src/clj_radix.clj
+++ b/src/clj_radix.clj
@@ -1,6 +1,6 @@
 (ns clj-radix
   (:refer-clojure
-    :exclude [remove merge merge-with])
+    :exclude [remove merge merge-with update])
   (:require
     [primitive-math :as p]
     [clj-radix.utils :refer :all]


### PR DESCRIPTION
Hello Zach,

This should avoid the following warnings:

```
Warning: protocol #'clj-radix/IRadixTree is overwriting function update
WARNING: update already refers to: #'clojure.core/update in namespace: clj-radix, being replaced by: #'clj-radix/update
```

I made the edit via GitHub's UI so haven't run the test suite etc. I didn't see `clojure.core/update` used anywhere after a quick find in my browser.

All the best!